### PR TITLE
ember-lifeline as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-htmlbars": "^3.1.0",
     "ember-cli-sass": "^10.0.1",
     "ember-decorators": "^6.0.0",
+    "ember-lifeline": "^4.1.5",
     "sass": "^1.22.7"
   },
   "devDependencies": {
@@ -54,7 +55,6 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-fn-helper-polyfill": "^1.0.2",
-    "ember-lifeline": "^4.1.5",
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-class-polyfill": "^1.0.6",


### PR DESCRIPTION
As another addon, `ember-lifeline` should be a dependency, rather than a devDependency