### PR TITLE
Prevent adding listeners if resize it already active

### DIFF
--- a/addon/components/re-sizable/component.js
+++ b/addon/components/re-sizable/component.js
@@ -76,6 +76,10 @@ class ReSizable extends Component {
 
   @action
   _onResizeStart(direction, event) {
+    if (this.isActive){
+      return;
+    }
+
     if (event.touches) {
       event = event.touches[0];
     } else {


### PR DESCRIPTION
In case mouse goes over an iframe element it steals mouse events and mouse-up may never reach the component, which leaves active listeners, so resize goes forever.