### PR TITLE
Mark event-listeners as `passive`

### DIFF
--- a/addon/components/re-sizable/component.js
+++ b/addon/components/re-sizable/component.js
@@ -97,10 +97,10 @@ class ReSizable extends Component {
     });
     this.set('_direction', direction);
 
-    addEventListener(this, window, 'mouseup', this._onMouseUp);
-    addEventListener(this, window, 'mousemove', this._onMouseMove);
-    addEventListener(this, window, 'touchmove', this._onTouchMove);
-    addEventListener(this, window, 'touchend', this._onMouseUp);
+    addEventListener(this, window, 'mouseup', this._onMouseUp, { passive: true });
+    addEventListener(this, window, 'mousemove', this._onMouseMove, { passive: true });
+    addEventListener(this, window, 'touchmove', this._onTouchMove, { passive: true });
+    addEventListener(this, window, 'touchend', this._onMouseUp, { passive: true });
   }
 
   _onTouchMove(event) {

--- a/addon/components/re-sizable/template.hbs
+++ b/addon/components/re-sizable/template.hbs
@@ -1,8 +1,8 @@
 {{#each this.directions as |dir|}}
   <div
     class={{concat "resizer " dir}}
-    {{on "mousedown" (fn this._onResizeStart dir)}}
-    {{on "touchstart" (fn this._onResizeStart dir)}}
+    {{on "mousedown" (fn this._onResizeStart dir) passive=true}}
+    {{on "touchstart" (fn this._onResizeStart dir) passive=true}}
     role="button"
   >
   </div>


### PR DESCRIPTION
This improves performance in some cases and removes some warnings from the console in Chrome.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners