### PR TITLE
Remove using a style-attribute as that requires `unsafe-inline` CSP

### DIFF
--- a/addon/components/re-sizable/component.js
+++ b/addon/components/re-sizable/component.js
@@ -1,14 +1,9 @@
 import Component from '@ember/component';
 import { dasherize, capitalize } from '@ember/string';
-import { htmlSafe } from '@ember/template';
 import { isNone } from '@ember/utils';
 import { action, computed } from '@ember/object';
-import {
-  attribute,
-  className,
-  classNames,
-  layout,
-} from '@ember-decorators/component';
+import { className, classNames, layout } from '@ember-decorators/component';
+import { observes, on } from '@ember-decorators/object';
 import template from './template';
 
 const getSize = (n) => (!isNaN(parseFloat(n)) && isFinite(n) ? `${n}px` : n);
@@ -40,19 +35,26 @@ class ReSizable extends Component {
   @className
   isActive = false;
 
-  @attribute
-  @computed('width', 'height', 'elementWidth', 'elementHeight')
-  get style() {
-    let s = '';
-    if (!isNone(this.width)) {
-      s = `width: ${getSize(this.elementWidth || this.width)};`;
+  @on('didRender')
+  // eslint-disable-next-line ember/no-observers
+  @observes('width', 'height', 'elementWidth', 'elementHeight')
+  style() {
+    if (isNone(this.width)) {
+      this.element.style.removeProperty('width');
+    } else {
+      this.element.style.setProperty(
+        'width',
+        getSize(this.elementWidth || this.width)
+      );
     }
-    if (!isNone(this.height)) {
-      s = `${s}height: ${getSize(this.elementHeight || this.height)};`;
+    if (isNone(this.height)) {
+      this.element.style.removeProperty('height');
+    } else {
+      this.element.style.setProperty(
+        'height',
+        getSize(this.elementHeight || this.height)
+      );
     }
-
-    // can we be sure this actually is safe?
-    return s.length ? htmlSafe(s) : null;
   }
 
   @computed('_width')

--- a/addon/components/re-sizable/component.js
+++ b/addon/components/re-sizable/component.js
@@ -35,6 +35,8 @@ class ReSizable extends Component {
   @className
   isActive = false;
 
+  // this is done so instead of with an `@attribute` because the latter requires `unsafe-inline` in `style-src`
+  // in the CSP settings. See https://github.com/evocount/ember-resizable/issues/405
   @on('didRender')
   // eslint-disable-next-line ember/no-observers
   @observes('width', 'height', 'elementWidth', 'elementHeight')

--- a/tests/integration/components/re-sizable/component-test.js
+++ b/tests/integration/components/re-sizable/component-test.js
@@ -68,7 +68,7 @@ module('Integration | Component | re-sizable', function (hooks) {
   });
 
   test('should react to width/height changes', async function (assert) {
-    assert.expect(3);
+    assert.expect(5);
 
     this.set('width', 100);
     this.set('height', 50);
@@ -85,8 +85,17 @@ module('Integration | Component | re-sizable', function (hooks) {
 
     assert.equal(
       this.element.querySelector('div').getAttribute('style'),
-      'width: 150px;height: 20%;'
+      'width: 150px; height: 20%;'
     );
+    assert.equal(
+      this.element.querySelector('div').getAttribute('style'),
+      'width: 150px; height: 20%;'
+    );
+
+    this.set('width', null);
+    this.set('height', undefined);
+
+    assert.equal(this.element.querySelector('div').getAttribute('style'), '');
   });
 
   test('should resize to input', async function (assert) {


### PR DESCRIPTION
Fixes #405

cc @ttill

In addition to this, #533 is required for a new version of `ember-resizable`.