### PR TITLE
Remove marking some of the events as `passive`

### DIFF
--- a/addon/components/re-sizable/component.js
+++ b/addon/components/re-sizable/component.js
@@ -117,18 +117,14 @@ class ReSizable extends Component {
     });
     this.set('_direction', direction);
 
-    window.addEventListener('mouseup', this._onMouseUp, {
-      passive: true,
-    });
+    window.addEventListener('mouseup', this._onMouseUp);
     window.addEventListener('mousemove', this._onMouseMove, {
       passive: true,
     });
     window.addEventListener('touchmove', this._onTouchMove, {
       passive: true,
     });
-    window.addEventListener('touchend', this._onMouseUp, {
-      passive: true,
-    });
+    window.addEventListener('touchend', this._onMouseUp);
   }
 
   @action

--- a/addon/components/re-sizable/template.hbs
+++ b/addon/components/re-sizable/template.hbs
@@ -2,8 +2,8 @@
   {{! template-lint-disable no-down-event-binding }}
   <div
     class={{concat "resizer " dir}}
-    {{on "mousedown" (fn this._onResizeStart dir) passive=true}}
-    {{on "touchstart" (fn this._onResizeStart dir) passive=true}}
+    {{on "mousedown" (fn this._onResizeStart dir)}}
+    {{on "touchstart" (fn this._onResizeStart dir)}}
     role="button"
   >
   </div>

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -40,6 +40,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),

--- a/tests/integration/components/re-sizable/component-test.js
+++ b/tests/integration/components/re-sizable/component-test.js
@@ -19,6 +19,15 @@ const DIRECTIONS = [
   'topLeft',
 ];
 
+async function _resize(direction) {
+  await triggerEvent(`div.${direction}`, 'mousedown', {
+    clientX: 110,
+    clientY: 40,
+  });
+  await triggerEvent(window, 'mousemove', { clientX: 160, clientY: 80 });
+  await triggerEvent(window, 'mouseup', {});
+}
+
 module('Integration | Component | re-sizable', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -103,12 +112,7 @@ module('Integration | Component | re-sizable', function (hooks) {
       let width = this.width;
       let height = this.height;
 
-      await triggerEvent(`div.${direction}`, 'mousedown', {
-        clientX: 110,
-        clientY: 40,
-      });
-      await triggerEvent(window, 'mousemove', { clientX: 160, clientY: 80 });
-      await triggerEvent(window, 'mouseup', {});
+      await _resize(direction);
 
       const dashDir = dasherize(direction);
       if (dashDir.includes('top')) {
@@ -129,5 +133,22 @@ module('Integration | Component | re-sizable', function (hooks) {
         `${height}px`
       );
     }
+  });
+
+  test('allows calling `preventDefault` on the start-resize event', async function (assert) {
+    assert.expect(1);
+
+    this.set('width', 200);
+    this.set('height', 150);
+
+    this.set('onResizeStart', (_direction, event) => event.preventDefault());
+
+    await render(
+      hbs`<ReSizable @width={{this.width}} @height={{this.height}} @onResizeStart={{this.onResizeStart}}>Hello</ReSizable>`
+    );
+
+    await _resize('top');
+
+    assert.ok(true);
   });
 });


### PR DESCRIPTION
Because some people might want to `preventDefault` them. Also, they are
not performance-sensitive as they aren't invoked multiple times per resize

cc @ttill

In addition to this, #533 and #534 are required for a new version of `ember-resizable`.