### PR TITLE
Add `@ember/string` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ember/string": "^3.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
@@ -1895,6 +1896,17 @@
       },
       "peerDependencies": {
         "ember-source": "^3.8 || 4"
+      }
+    },
+    "node_modules/@ember/string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
+      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/@ember/test-helpers": {
@@ -26420,6 +26432,14 @@
         "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.11",
         "ember-modifier-manager-polyfill": "^1.2.0"
+      }
+    },
+    "@ember/string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
+      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "requires": {
+        "ember-cli-babel": "^7.26.6"
       }
     },
     "@ember/test-helpers": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "@ember/string": "^3.0.1",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-sass": "^11.0.1",


### PR DESCRIPTION
To fix Ember 4.10 deprecation warnings